### PR TITLE
fix: StaticMeshActor AABB 제대로 그려주도록 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(dir:*)"
+      "Bash(dir:*)",
+      "Bash(msbuild:*)",
+      "Bash(\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe\" Engine.sln /p:Configuration=Debug /p:Platform=x64)"
     ],
     "deny": [],
     "ask": []

--- a/Engine/Source/Asset/Private/StaticMesh.cpp
+++ b/Engine/Source/Asset/Private/StaticMesh.cpp
@@ -64,3 +64,27 @@ void UStaticMesh::ReleaseRenderBuffers()
 		IndexBuffer = nullptr;
 	}
 }
+
+FAABB UStaticMesh::CalculateAABB() const
+{
+	if (StaticMeshData.Vertices.empty())
+	{
+		return FAABB();
+	}
+
+	FVector Min = StaticMeshData.Vertices[0].Position;
+	FVector Max = StaticMeshData.Vertices[0].Position;
+
+	for (const FVertex& Vertex : StaticMeshData.Vertices)
+	{
+		Min.X = std::min(Min.X, Vertex.Position.X);
+		Min.Y = std::min(Min.Y, Vertex.Position.Y);
+		Min.Z = std::min(Min.Z, Vertex.Position.Z);
+
+		Max.X = std::max(Max.X, Vertex.Position.X);
+		Max.Y = std::max(Max.Y, Vertex.Position.Y);
+		Max.Z = std::max(Max.Z, Vertex.Position.Z);
+	}
+
+	return FAABB(Min, Max);
+}

--- a/Engine/Source/Asset/Public/StaticMesh.h
+++ b/Engine/Source/Asset/Public/StaticMesh.h
@@ -82,6 +82,12 @@ public:
 	 */
 	void ReleaseRenderBuffers();
 
+	/**
+	 * @brief 메시의 AABB를 계산
+	 * @return 계산된 AABB
+	 */
+	FAABB CalculateAABB() const;
+
 protected:
 	/** 실제 메시 데이터 */
 	FStaticMesh StaticMeshData;

--- a/Engine/Source/Component/Mesh/Private/CubeComponent.cpp
+++ b/Engine/Source/Component/Mesh/Private/CubeComponent.cpp
@@ -16,7 +16,6 @@ UCubeComponent::UCubeComponent()
 	NumVertices = ResourceManager.GetNumVertices(Type);
 	RenderState.CullMode = ECullMode::Back;
 	RenderState.FillMode = EFillMode::Solid;
-	// BoundingBox = &ResourceManager.GetAABB(Type); // 제거됨: StaticMeshActor 시스템 사용
-	BoundingBox = nullptr;
+	BoundingVolume = nullptr;
 }
 

--- a/Engine/Source/Component/Mesh/Private/SphereComponent.cpp
+++ b/Engine/Source/Component/Mesh/Private/SphereComponent.cpp
@@ -16,7 +16,6 @@ USphereComponent::USphereComponent()
 	NumVertices = ResourceManager.GetNumVertices(Type);
 	RenderState.CullMode = ECullMode::Back;
 	RenderState.FillMode = EFillMode::Solid;
-	// BoundingBox = &ResourceManager.GetAABB(Type); // 제거됨: StaticMeshActor 시스템 사용
-	BoundingBox = nullptr;
+	BoundingVolume = nullptr;
 }
 

--- a/Engine/Source/Component/Mesh/Private/SquareComponent.cpp
+++ b/Engine/Source/Component/Mesh/Private/SquareComponent.cpp
@@ -15,6 +15,5 @@ USquareComponent::USquareComponent()
 	NumVertices = ResourceManager.GetNumVertices(Type);
 	RenderState.CullMode = ECullMode::None;
 	RenderState.FillMode = EFillMode::Solid;
-	// BoundingBox = &ResourceManager.GetAABB(Type); // 제거됨: StaticMeshActor 시스템 사용
-	BoundingBox = nullptr;
+	BoundingVolume = nullptr;
 }

--- a/Engine/Source/Component/Mesh/Private/TriangleComponent.cpp
+++ b/Engine/Source/Component/Mesh/Private/TriangleComponent.cpp
@@ -15,6 +15,5 @@ UTriangleComponent::UTriangleComponent()
 	NumVertices = ResourceManager.GetNumVertices(Type);
 	RenderState.CullMode = ECullMode::None;
 	RenderState.FillMode = EFillMode::Solid;
-	// BoundingBox = &ResourceManager.GetAABB(Type); // 제거됨: StaticMeshActor 시스템 사용
-	BoundingBox = nullptr;
+	BoundingVolume = nullptr;
 }

--- a/Engine/Source/Component/Private/PrimitiveComponent.cpp
+++ b/Engine/Source/Component/Private/PrimitiveComponent.cpp
@@ -62,12 +62,13 @@ const FMatrix& USceneComponent::GetWorldTransformMatrix() const
 {
 	if (bIsTransformDirty)
 	{
-		WorldTransformMatrix = FMatrix::GetModelMatrix(RelativeLocation, FVector::GetDegreeToRadian(RelativeRotation), RelativeScale3D);
+		WorldTransformMatrix = FMatrix::GetModelMatrix(GetRelativeLocation(), FVector::GetDegreeToRadian(GetRelativeRotation()), GetRelativeScale3D());
 
-
-		for (USceneComponent* Ancester = ParentAttachment; Ancester && Ancester->ParentAttachment; Ancester = Ancester->ParentAttachment)
+		// 부모 컴포넌트가 있는 경우 부모의 변환도 적용
+		if (ParentAttachment)
 		{
-			WorldTransformMatrix *= FMatrix::GetModelMatrix(Ancester->RelativeLocation, FVector::GetDegreeToRadian(Ancester->RelativeRotation), Ancester->RelativeScale3D);
+			FMatrix ParentTransform = ParentAttachment->GetWorldTransformMatrix();
+			WorldTransformMatrix = ParentTransform * WorldTransformMatrix;
 		}
 
 		bIsTransformDirty = false;
@@ -115,39 +116,6 @@ D3D11_PRIMITIVE_TOPOLOGY UPrimitiveComponent::GetTopology() const
 	return Topology;
 }
 
-void UPrimitiveComponent::GetWorldAABB(FVector& OutMin, FVector& OutMax) const
-{
-	if (!BoundingBox)	return;
-
-	if (BoundingBox->GetType() == EBoundingVolumeType::AABB)
-	{
-		const FAABB* LocalAABB = static_cast<const FAABB*>(BoundingBox);
-		FVector LocalCorners[8] =
-		{
-			FVector(LocalAABB->Min.X, LocalAABB->Min.Y, LocalAABB->Min.Z), FVector(LocalAABB->Max.X, LocalAABB->Min.Y, LocalAABB->Min.Z),
-			FVector(LocalAABB->Min.X, LocalAABB->Max.Y, LocalAABB->Min.Z), FVector(LocalAABB->Max.X, LocalAABB->Max.Y, LocalAABB->Min.Z),
-			FVector(LocalAABB->Min.X, LocalAABB->Min.Y, LocalAABB->Max.Z), FVector(LocalAABB->Max.X, LocalAABB->Min.Y, LocalAABB->Max.Z),
-			FVector(LocalAABB->Min.X, LocalAABB->Max.Y, LocalAABB->Max.Z), FVector(LocalAABB->Max.X, LocalAABB->Max.Y, LocalAABB->Max.Z)
-		};
-		const FMatrix& WorldTransform = GetWorldTransformMatrix();
-		FVector WorldMin(+FLT_MAX, +FLT_MAX, +FLT_MAX);
-		FVector WorldMax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
-
-		for (int i = 0; i < 8; i++)
-		{
-			FVector4 WorldCorner = FVector4(LocalCorners[i].X, LocalCorners[i].Y, LocalCorners[i].Z, 1.0f) * WorldTransform;
-			WorldMin.X = std::min(WorldMin.X, WorldCorner.X);
-			WorldMin.Y = std::min(WorldMin.Y, WorldCorner.Y);
-			WorldMin.Z = std::min(WorldMin.Z, WorldCorner.Z);
-			WorldMax.X = std::max(WorldMax.X, WorldCorner.X);
-			WorldMax.Y = std::max(WorldMax.Y, WorldCorner.Y);
-			WorldMax.Z = std::max(WorldMax.Z, WorldCorner.Z);
-		}
-		OutMin = WorldMin;
-		OutMax = WorldMax;
-	}
-}
-
 // 공통 렌더링 인터페이스 기본 구현
 bool UPrimitiveComponent::HasRenderData() const
 {
@@ -192,6 +160,22 @@ EShaderType UPrimitiveComponent::GetShaderType() const
 {
 	// 기본 프리미티브는 기본 셰이더 사용
 	return EShaderType::Default;
+}
+
+void UPrimitiveComponent::GetWorldAABB(FVector& OutMin, FVector& OutMax) const
+{
+	// 기본 구현: AABB가 없으면 빈 박스 반환
+	if (BoundingVolume && BoundingVolume->GetType() == EBoundingVolumeType::AABB)
+	{
+		FAABB* aabb = static_cast<FAABB*>(BoundingVolume);
+		OutMin = aabb->Min;
+		OutMax = aabb->Max;
+	}
+	else
+	{
+		OutMin = FVector(0.0f, 0.0f, 0.0f);
+		OutMax = FVector(0.0f, 0.0f, 0.0f);
+	}
 }
 
 /*

--- a/Engine/Source/Component/Private/SceneComponent.cpp
+++ b/Engine/Source/Component/Private/SceneComponent.cpp
@@ -52,6 +52,8 @@ void USceneComponent::MarkAsDirty()
 	bIsTransformDirty = true;
 	bIsTransformDirtyInverse = true;
 
+	OnTransformChanged();
+
 	for (USceneComponent* Child : Children)
 	{
 		Child->MarkAsDirty();

--- a/Engine/Source/Component/Public/PrimitiveComponent.h
+++ b/Engine/Source/Component/Public/PrimitiveComponent.h
@@ -25,9 +25,6 @@ public:
 	FVector4 GetColor() const { return Color; }
 	void SetColor(const FVector4& InColor) { Color = InColor; }
 
-	const IBoundingVolume* GetBoundingBox() const { return BoundingBox; }
-	void GetWorldAABB(FVector& OutMin, FVector& OutMax) const;
-
 	EPrimitiveType GetPrimitiveType() const { return Type; }
 
 	// 공통 렌더링 인터페이스
@@ -40,7 +37,21 @@ public:
 	virtual bool UseIndexedRendering() const;
 	virtual EShaderType GetShaderType() const;
 
+	// BoundingVolume 관련 함수들
+	/**
+	 * @brief 월드 좌표계 AABB를 가져옴
+	 * @param OutMin 최소 좌표 (출력)
+	 * @param OutMax 최대 좌표 (출력)
+	 */
+	virtual void GetWorldAABB(FVector& OutMin, FVector& OutMax) const;
+
+	/**
+	 * @brief BoundingVolume을 가져옴
+	 */
+	IBoundingVolume* GetBoundingVolume() const { return BoundingVolume; }
+
 protected:
+	// 기즈모 때문에 지우면 안될듯..?
 	const TArray<FVertex>* Vertices = nullptr;
 	FVector4 Color = FVector4{ 0.f,0.f,0.f,0.f };
 	ID3D11Buffer* Vertexbuffer = nullptr;
@@ -48,8 +59,9 @@ protected:
 	D3D11_PRIMITIVE_TOPOLOGY Topology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
 	FRenderState RenderState = {};
 	EPrimitiveType Type = EPrimitiveType::Cube;
+	//
 
 	bool bVisible = true;
 
-	const IBoundingVolume* BoundingBox = nullptr;
+	IBoundingVolume* BoundingVolume = nullptr;
 };

--- a/Engine/Source/Component/Public/SceneComponent.h
+++ b/Engine/Source/Component/Public/SceneComponent.h
@@ -14,6 +14,7 @@ public:
 	void RemoveChild(USceneComponent* ChildDeleted);
 
 	void MarkAsDirty();
+	virtual void OnTransformChanged() {}
 
 	void SetRelativeLocation(const FVector& Location);
 	void SetRelativeRotation(const FVector& Rotation);

--- a/Engine/Source/Component/Public/StaticMeshComponent.h
+++ b/Engine/Source/Component/Public/StaticMeshComponent.h
@@ -43,6 +43,16 @@ public:
 	virtual bool UseIndexedRendering() const override;
 	virtual EShaderType GetShaderType() const override;
 
+	// BoundingVolume 관련 기능
+	/**
+	 * @brief 스태틱 메시를 기반으로 AABB 계산
+	 * @return 계산된 AABB
+	 */
+	FAABB GetAABB() const;
+
+	// PrimitiveComponent 오버라이드
+	virtual void GetWorldAABB(FVector& OutMin, FVector& OutMax) const override;
+
 protected:
 	// UMeshComponent로부터 재정의
 	virtual void InitializeMeshRenderData() override;

--- a/Engine/Source/Editor/Private/Editor.cpp
+++ b/Engine/Source/Editor/Private/Editor.cpp
@@ -47,8 +47,11 @@ void UEditor::Update()
 	AActor* SelectedActor = ULevelManager::GetInstance().GetCurrentLevel()->GetSelectedActor();
 	if (SelectedActor)
 	{
-		for (const auto& Component : SelectedActor->GetOwnedComponents())
+		const auto& Components = SelectedActor->GetOwnedComponents();
+
+		for (const auto& Component : Components)
 		{
+			UE_LOG_DEBUG("Component: %p\n", Component.Get());
 			if (auto PrimitiveComponent = Cast<UPrimitiveComponent>(Component))
 			{
 				FVector WorldMin, WorldMax;
@@ -56,7 +59,6 @@ void UEditor::Update()
 
 				// 프리미티브와 바운딩박스 플래그가 모두 켜져있을 때만 바운딩박스 표시
 				uint64 ShowFlags = ULevelManager::GetInstance().GetCurrentLevel()->GetShowFlags();
-
 				if ((ShowFlags & EEngineShowFlags::SF_Primitives) && (ShowFlags & EEngineShowFlags::SF_Bounds))
 				{
 					BatchLines.UpdateBoundingBoxVertices(FAABB(WorldMin, WorldMax));

--- a/Engine/Source/Global/Matrix.cpp
+++ b/Engine/Source/Global/Matrix.cpp
@@ -267,11 +267,9 @@ FVector4 FMatrix::VectorMultiply(const FVector4& v, const FMatrix& m)
 FVector FMatrix::VectorMultiply(const FVector& v, const FMatrix& m)
 {
 	FVector result = {};
-	result.X = (v.X * m.Data[0][0]) + (v.Y * m.Data[1][0]) + (v.Z * m.Data[2][0]);
-	result.Y = (v.X * m.Data[0][1]) + (v.Y * m.Data[1][1]) + (v.Z * m.Data[2][1]);
-	result.Z = (v.X * m.Data[0][2]) + (v.Y * m.Data[1][2]) + (v.Z * m.Data[2][2]);
-	//result.W = (v.X * m.Data[0][3]) + (v.Y * m.Data[1][3]) + (v.Z * m.Data[2][3]) + (v.W * m.Data[3][3]);
-
+	result.X = (v.X * m.Data[0][0]) + (v.Y * m.Data[1][0]) + (v.Z * m.Data[2][0]) + m.Data[3][0];
+	result.Y = (v.X * m.Data[0][1]) + (v.Y * m.Data[1][1]) + (v.Z * m.Data[2][1]) + m.Data[3][1];
+	result.Z = (v.X * m.Data[0][2]) + (v.Y * m.Data[1][2]) + (v.Z * m.Data[2][2]) + m.Data[3][2];
 
 	return result;
 }

--- a/Engine/Source/Global/Vector.h
+++ b/Engine/Source/Global/Vector.h
@@ -210,7 +210,6 @@ struct FVector4
 	 */
 	FVector4(float InX, float InY, float InZ, float InW);
 
-
 	/**
 	 * @brief FVector를 Param으로 넘기는 생성자
 	 */

--- a/Engine/Source/Render/UI/Widget/Private/PrimitiveSpawnWidget.cpp
+++ b/Engine/Source/Render/UI/Widget/Private/PrimitiveSpawnWidget.cpp
@@ -119,7 +119,7 @@ void UPrimitiveSpawnWidget::SpawnActors() const
 	// 지정된 개수만큼 액터 생성
 	for (int32 i = 0; i < NumberOfSpawn; i++)
 	{
-		AStaticMeshActor* StaticMeshActor = CurrentLevel->SpawnActor<AStaticMeshActor>();
+		AStaticMeshActor* StaticMeshActor = CurrentLevel->SpawnActor<AStaticMeshActor>("StaticMeshActor");
 		AActor* NewActor = nullptr;
 
 		if (StaticMeshActor)


### PR DESCRIPTION
[StaticMeshActor]
- StaticMeshActor가 AABB를 관리하도록 함.
- 기존의 FMatrix::VectorMultiply 함수가 w값을 0으로 가정하고 곱해줘서 위치 정보를 못받아오고 있었음. 수정하여 위치도 제대로 받아오도록 수정.;