### PR TITLE
fix: Picking Issue

### DIFF
--- a/Engine/Source/Editor/Private/ObjectPicker.cpp
+++ b/Engine/Source/Editor/Private/ObjectPicker.cpp
@@ -4,15 +4,6 @@
 #include "Editor/Public/Gizmo.h"
 #include "Runtime/Component/Public/PrimitiveComponent.h"
 
-UObjectPicker::UObjectPicker(UCamera& InCamera)
-	:Camera( InCamera)
-{}
-
-void UObjectPicker::SetCamera(UCamera& Camera)
-{
-	this->Camera = Camera;
-}
-
 FRay UObjectPicker::GetModelRay(const FRay& Ray, UPrimitiveComponent* Primitive)
 {
 	FMatrix ModelInverse = Primitive->GetWorldTransformMatrixInverse();
@@ -55,6 +46,11 @@ UPrimitiveComponent* UObjectPicker::PickPrimitive(const FRay& WorldRay, TArray<U
 
 void UObjectPicker::PickGizmo( const FRay& WorldRay, UGizmo& Gizmo, FVector& CollisionPoint)
 {
+    if (!Camera)
+    {
+        Gizmo.SetGizmoDirection(EGizmoDirection::None);
+        return;
+    }
 	//Forward, Right, Up순으로 테스트할거임.
 	//원기둥 위의 한 점 P, 축 위의 임의의 점 A에(기즈모 포지션) 대해, AP벡터와 축 벡터 V와 피타고라스 정리를 적용해서 점 P의 축부터의 거리 r을 구할 수 있음.
 	//r이 원기둥의 반지름과 같다고 방정식을 세운 후 근의공식을 적용해서 충돌여부 파악하고 distance를 구할 수 있음.
@@ -202,9 +198,10 @@ bool UObjectPicker::IsRayPrimitiveCollided(const FRay& ModelRay, UPrimitiveCompo
 bool UObjectPicker::IsRayTriangleCollided(const FRay& Ray, const FVector& Vertex1, const FVector& Vertex2, const FVector& Vertex3,
                            const FMatrix& ModelMatrix, float* Distance)
 {
-	FVector CameraForward = Camera.GetForward(); //카메라 정보 필요
-	float NearZ = Camera.GetNearZ();
-	float FarZ = Camera.GetFarZ();
+	if (!Camera) { return false; }
+	FVector CameraForward = Camera->GetForward(); //카메라 정보 필요
+	float NearZ = Camera->GetNearZ();
+	float FarZ = Camera->GetFarZ();
 	FMatrix ModelTransform; //Primitive로부터 얻어내야함.(카메라가 처리하는게 나을듯)
 
 

--- a/Engine/Source/Editor/Public/Editor.h
+++ b/Engine/Source/Editor/Public/Editor.h
@@ -38,11 +38,14 @@ private:
 	void ProcessMouseInput(ULevel* InLevel);
 	TArray<UPrimitiveComponent*> FindCandidatePrimitives(ULevel* InLevel);
 
-	FVector GetGizmoDragLocation(FRay& WorldRay);
-	FVector GetGizmoDragRotation(FRay& WorldRay);
-	FVector GetGizmoDragScale(FRay& WorldRay);
+	FVector GetGizmoDragLocation(FRay& WorldRay, UCamera& Camera);
+	FVector GetGizmoDragRotation(FRay& WorldRay, UCamera& Camera);
+	FVector GetGizmoDragScale(FRay& WorldRay, UCamera& Camera);
 
-	UCamera Camera;
+	// 현재 마우스가 위치한 뷰포트(없으면 0)의 카메라를 반환
+	UCamera* GetActivePickingCamera();
+
+	UCamera Camera; // legacy editor camera (not used for picking)
 	UObjectPicker ObjectPicker;
 
 	const float MinScale = 0.01f;

--- a/Engine/Source/Editor/Public/ObjectPicker.h
+++ b/Engine/Source/Editor/Public/ObjectPicker.h
@@ -11,8 +11,9 @@ struct FRay;
 class UObjectPicker : public UObject
 {
 public:
-	UObjectPicker(UCamera& InCamera);
-	void SetCamera(UCamera& Camera);
+	UObjectPicker() = default;
+	// Assign camera to use for ray tests (per-frame/per-viewport)
+	void SetCamera(UCamera* InCamera) { Camera = InCamera; }
 	UPrimitiveComponent* PickPrimitive( const FRay& WorldRay, TArray<UPrimitiveComponent*> Candidate, float* Distance);
 	void PickGizmo(const FRay& WorldRay, UGizmo& Gizmo, FVector& CollisionPoint);
 	bool IsRayCollideWithPlane(const FRay& WorldRay, FVector PlanePoint, FVector Normal, FVector& PointOnPlane);
@@ -22,9 +23,6 @@ private:
 	FRay GetModelRay(const FRay& Ray, UPrimitiveComponent* Primitive);
 	bool IsRayTriangleCollided(const FRay& Ray, const FVector& Vertex1, const FVector& Vertex2, const FVector& Vertex3,
 		const FMatrix& ModelMatrix, float* Distance);
-
-	
-
-
-	UCamera& Camera;
+private:
+	UCamera* Camera = nullptr;
 };

--- a/Engine/Source/Manager/Viewport/Public/ViewportManager.h
+++ b/Engine/Source/Manager/Viewport/Public/ViewportManager.h
@@ -31,7 +31,13 @@ public:
     SWindow* GetRoot();
 
 	// 리프 Rect 수집
-	void GetLeafRects(TArray<FRect>& OutRects);
+    void GetLeafRects(TArray<FRect>& OutRects);
+
+    // 현재 마우스가 위치한 뷰포트 인덱스(-1이면 없음)
+    int32 GetViewportIndexUnderMouse() const;
+
+    // 주어진 뷰포트 인덱스 기준으로 로컬 NDC 계산(true면 성공)
+    bool ComputeLocalNDCForViewport(int32 Index, float& OutNdcX, float& OutNdcY) const;
 
 	// 공유 오쏘 카메라(읽기 전용 포인터를 클라에 주입)
     UCamera* GetOrthographicCamera() const { return OrthographicCamera; }


### PR DESCRIPTION
Editor camera를 기준으로 받아오던 피킹레이를 Veiwport카메라로 바꿈으로써 해결
1. 현재 마우스의 화면좌표를 받아 각 뷰포트 Rect 중 어디에 포함되는지 판별
2. 선택된 뷰포트의 로컬 좌표로 변환
3. 로컬좌표 기반으로 레이판별