### PR TITLE
fix: orthographic Rendering issue

### DIFF
--- a/Engine/Source/Manager/Input/Private/InputManager.cpp
+++ b/Engine/Source/Manager/Input/Private/InputManager.cpp
@@ -122,7 +122,7 @@ void UInputManager::Update(const FAppWindow* InWindow)
 	UpdateMousePosition(InWindow);
 
 	// 마우스 휠 델타 리셋
-	MouseWheelDelta = 0.0f;
+	//MouseWheelDelta = 0.0f;
 
 	// 더블클릭 감지 업데이트
 	UpdateDoubleClickDetection();
@@ -331,10 +331,8 @@ void UInputManager::ProcessKeyMessage(uint32 InMessage, WPARAM WParam, LPARAM LP
 
 	case WM_MOUSEWHEEL:
 		{
-			// WParam의 상위 16비트에 휠 델타 값이 들어있음
-			// WHEEL_DELTA(120)로 정규화하여 -1.0f ~ 1.0f 범위로 변환
 			short WheelDelta = GET_WHEEL_DELTA_WPARAM(WParam);
-			MouseWheelDelta = static_cast<float>(WheelDelta) / WHEEL_DELTA;
+			MouseWheelDelta = static_cast<float>(WheelDelta) / (WHEEL_DELTA * 10.0f);
 		}
 		break;
 

--- a/Engine/Source/Manager/Input/Public/InputManager.h
+++ b/Engine/Source/Manager/Input/Public/InputManager.h
@@ -36,6 +36,7 @@ public:
 
 	// Mouse Wheel
 	float GetMouseWheelDelta() const { return MouseWheelDelta; }
+	void  SetMouseWheelDelta(float InMouseWheelDelta) { MouseWheelDelta = InMouseWheelDelta; }
 
 	// Double Click Detection
 	bool IsMouseDoubleClicked(EKeyInput InMouseButton) const;

--- a/Engine/Source/Window/Private/ViewportClient.cpp
+++ b/Engine/Source/Window/Private/ViewportClient.cpp
@@ -21,7 +21,7 @@ void FViewportClient::Tick(float InDeltaSeconds)
         if (OrthoGraphicCamera)
         {
             ApplyOrthoBasisForViewType(*OrthoGraphicCamera);  // Top/Front/Right 등 기준 축 세팅
-            OrthoGraphicCamera->SetCameraType(ECameraType::ECT_Orthographic);
+           // OrthoGraphicCamera->SetCameraType(ECameraType::ECT_Orthographic);
             OrthoGraphicCamera->Update();                     // 내부에서 입력 처리 + View/Proj 갱신
         }
     }


### PR DESCRIPTION
이제 직교투영 카메라가 툴바에서 바로 선택시 적용됩니다
1. client들은 공유 orthographic camera를 가집니다. 하지만 right,left,top...등등
2. 그 설정된 축들을 기반으로 client개별적으로 화면행렬을 계산합니다. 위치는 공유됩니다.