### PR TITLE
PR: obj import error

### DIFF
--- a/Engine/Source/Asset/Public/ObjImporter.h
+++ b/Engine/Source/Asset/Public/ObjImporter.h
@@ -57,13 +57,11 @@ private:
 	 * @param GlobalNormals 전역 노멀 목록
 	 */
 	static void ParseOBJLine(const FString& Line,
-		FObjInfo& CurrentObject,
-		TArray<FObjInfo>& AllObjects,
+		FObjInfo& ObjectInfo,
 		TArray<FVector>& GlobalVertices,
 		TArray<FVector2>& GlobalUVs,
 		TArray<FVector>& GlobalNormals,
 		int32& CurrentSectionIndex,
-		FString& CurrentGroupName,
 		FString& CurrentMaterialName,
 		TMap<FString, FObjMaterialInfo>& MaterialLibrary,
 		const FString& ObjDirectory);

--- a/Engine/Source/Asset/Public/StaticMeshData.h
+++ b/Engine/Source/Asset/Public/StaticMeshData.h
@@ -33,17 +33,20 @@ struct FObjMaterialInfo
 	}
 };
 
+/**
+ * @brief 스태틱 메시 내 객체의 섹션 정보
+ * 각 섹션은 동일한 머티리얼을 사용하는 삼각형 그룹을 나타냄.
+ */
 struct FObjSectionInfo
 {
-	FString SectionName;	// OBJ 'g' 키워드로 정의된 섹션 이름
 	FString MaterialName;	// 섹션에서 사용할 머티리얼 이름
 	int32 StartIndex = 0;	// 섹션 시작 인덱스 (파싱된 인덱스 배열 기준)
 	int32 IndexCount = 0;	// 섹션에 포함된 인덱스 수
 
 	FObjSectionInfo() = default;
 
-	FObjSectionInfo(const FString& InSectionName, int32 InStartIndex)
-		: SectionName(InSectionName)
+	FObjSectionInfo(const FString& InMaterialName, int32 InStartIndex)
+		: MaterialName(InMaterialName)
 		, StartIndex(InStartIndex)
 	{
 	}
@@ -65,8 +68,8 @@ struct FObjInfo
 	TArray<uint32> VertexIndexList;				// OBJ 'f' 명령어의 정점 인덱스 (VertexList 참조)
 	TArray<uint32> UVIndexList;					// OBJ 'f' 명령어의 UV 인덱스 (UVList 참조)
 	TArray<uint32> NormalIndexList;			// OBJ 'f' 명령어의 노멀 인덱스 (NormalList 참조)
-	TArray<FObjSectionInfo> Sections;		// OBJ 그룹과 머티리얼을 위한 섹션 정보
-	TMap<FString, FObjMaterialInfo> MaterialInfos;	// 이 객체에서 참조하는 머티리얼 정보
+	TArray<FObjSectionInfo> Sections;		// OBJ 'usemtl' 명령어에 따라 분리된 동일 머티리얼을 사용하는 섹션 정보
+	TMap<FString, FObjMaterialInfo> MaterialInfos;	// 참조하는 머티리얼 정보. Sections에서 MaterialName을 사용해 MaterialInfos 찾음.
 
 	FObjInfo() = default;
 

--- a/Engine/Source/Manager/Asset/Private/AssetManager.cpp
+++ b/Engine/Source/Manager/Asset/Private/AssetManager.cpp
@@ -522,9 +522,8 @@ TObjectPtr<UStaticMesh> UAssetManager::LoadStaticMesh(const FString& InFilePath)
 
 		if(CheckEmptyMaterialSlots(StaticMeshData.Sections))
 		{
-			UE_LOG_WARNING("StaticMesh에 머티리얼이 없거나 섹션에 머티리얼이 할당되지 않았습니다. 기본 머티리얼을 할당합니다.");
+			InsertDefaultMaterial(StaticMeshData, MaterialSlots);
 		}
-		InsertDefaultMaterial(StaticMeshData, MaterialSlots);
 
 		NewStaticMesh->SetStaticMeshData(StaticMeshData);
 		NewStaticMesh->SetMaterialSlots(MaterialSlots);


### PR DESCRIPTION
obj의 o 토큰으로 FObjInfo 객체를 새로 만드는 것은 의미가 없고, g를 이용해 섹션을 나누는 방식은 머티리얼 단위로 섹션을 나누려는 의도와 맞지 않아 머티리얼이 정상적으로 적용되지 않는 문제를 일으킴.
- o 토큰 처리를 없애고 하나의 obj 파일을 파싱할 때 FObjInfo 객체 하나에 담도록 수정.
- g 토큰 처리 로직을 없애고 usemtl 토큰으로 섹션을 나누도록 파싱 로직 수정.